### PR TITLE
Allow secrets to be in namespaces

### DIFF
--- a/cmd/patch.go
+++ b/cmd/patch.go
@@ -3,7 +3,7 @@ package cmd
 import "encoding/base64"
 
 type PatchOpt struct {
-	Name                  string
+	Metadata              map[string]string
 	ClearTextDataMutation map[string][]byte
 	KeySetMutation        KeySetMutation
 	Rotate                bool
@@ -20,13 +20,13 @@ func Patch(resource []byte, opt PatchOpt) ([]byte, error) {
 		}
 	}
 	// mutate metadata
-	if opt.Name != "" {
-		metadata, ok := rs["metadata"].(map[interface{}]interface{})
-		if !ok {
-			metadata = make(map[interface{}]interface{})
-			rs["metadata"] = metadata
-		}
-		metadata["name"] = opt.Name
+	metadata, ok := rs["metadata"].(map[interface{}]interface{})
+	if !ok {
+		metadata = make(map[interface{}]interface{})
+		rs["metadata"] = metadata
+	}
+	for key, value := range opt.Metadata {
+		metadata[key] = value
 	}
 	// mutate data
 	data := rs.data()

--- a/cmd/patch_test.go
+++ b/cmd/patch_test.go
@@ -18,7 +18,10 @@ metadata:
 		t.Fatal(err)
 	}
 	assertPatchResultEq(t, encrypted, PatchOpt{}, source)
-	assertPatchResultEq(t, encrypted, PatchOpt{Name: "updated_name"}, `data:
+	assertPatchResultEq(t,
+		encrypted,
+		PatchOpt{Metadata: map[string]string{"name": "updated_name"}},
+		`data:
   another_key: value
   key: value
   key_to_remove: value
@@ -28,8 +31,20 @@ metadata:
 `)
 	assertPatchResultEq(t,
 		encrypted,
+		PatchOpt{Metadata: map[string]string{"namespace": "beyond"}},
+		`data:
+  another_key: value
+  key: value
+  key_to_remove: value
+kind: Secret
+metadata:
+  name: original_name
+  namespace: beyond
+`)
+	assertPatchResultEq(t,
+		encrypted,
 		PatchOpt{
-			Name: "updated-secret",
+			Metadata: map[string]string{"name": "updated-secret"},
 			ClearTextDataMutation: map[string][]byte{
 				"key":           []byte("updated_value"),
 				"key_added":     []byte("value"),


### PR DESCRIPTION
Adds `namespace` as an allowed metadata key. Secrets can now be put in namespaces using `kubesec patch` and `kubectl create`.

The `create` command previously appeared to support `--metadata`, but never used it.