### PR TITLE
Fix case sensitive import for logrus

### DIFF
--- a/aws/kms/client.go
+++ b/aws/kms/client.go
@@ -1,7 +1,7 @@
 package kms
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"

--- a/cmd/decrypt.go
+++ b/cmd/decrypt.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	awskms "github.com/shyiko/kubesec/aws/kms"
 	"github.com/shyiko/kubesec/crypto/aes"
 	googlecloudkms "github.com/shyiko/kubesec/gcp/kms"

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -4,7 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/glide.lock
+++ b/glide.lock
@@ -55,7 +55,7 @@ imports:
   - cmd
   - cmd/install
   - match
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: f006c2ac4710855cf0f916dd6b77acf6b048dc6e
 - name: github.com/spf13/cobra
   version: b26b538f693051ac6518e65672de3144ce3fbedc

--- a/glide.yaml
+++ b/glide.yaml
@@ -3,7 +3,7 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/pflag
 - package: gopkg.in/yaml.v2
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: google.golang.org/api
   subpackages:
   - cloudkms

--- a/gpg/gpg.go
+++ b/gpg/gpg.go
@@ -2,7 +2,7 @@ package gpg
 
 import (
 	"errors"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"os"
 	"os/exec"

--- a/kubesec.go
+++ b/kubesec.go
@@ -5,7 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/shyiko/kubesec/cli"
 	kubesec "github.com/shyiko/kubesec/cmd"
 	"github.com/shyiko/kubesec/gpg"


### PR DESCRIPTION
This is causing issues in case-sensitive build tools like [bazel](http://bazel.build).